### PR TITLE
Simplify message creation payload

### DIFF
--- a/lib/postoffice_web/controllers/api/message_controller.ex
+++ b/lib/postoffice_web/controllers/api/message_controller.ex
@@ -5,7 +5,7 @@ defmodule PostofficeWeb.Api.MessageController do
 
   action_fallback PostofficeWeb.FallbackController
 
-  def create(conn, %{"message" => message_params}) do
+  def create(conn, message_params) do
     with {:ok, %Message{} = message} <- Postoffice.receive_message(message_params) do
       conn
       |> put_status(:created)

--- a/test/postoffice_web/controllers/api/message_controller_test.exs
+++ b/test/postoffice_web/controllers/api/message_controller_test.exs
@@ -23,12 +23,12 @@ defmodule PostofficeWeb.Api.MessageControllerTest do
 
   describe "create message" do
     test "renders message when data is valid", %{conn: conn} do
-      conn = post(conn, Routes.api_message_path(conn, :create), message: @create_attrs)
+      conn = post(conn, Routes.api_message_path(conn, :create), @create_attrs)
       assert %{"public_id" => id} = json_response(conn, 201)["data"]
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, Routes.api_message_path(conn, :create), message: @invalid_attrs)
+      conn = post(conn, Routes.api_message_path(conn, :create), @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end


### PR DESCRIPTION
Remove `message` key from message creation api

https://github.com/lonamiaec/postoffice/issues/12