### PR TITLE
Propagate attributes to http payload

### DIFF
--- a/lib/postoffice/workers/http.ex
+++ b/lib/postoffice/workers/http.ex
@@ -35,6 +35,7 @@ defmodule Postoffice.Workers.Http do
        ) do
     message_id = id || 0
     historical_payload = if is_list(payload) == false, do: [payload], else: payload
+    args = Map.put(args, "payload", Map.merge(payload, %{"attributes" => attributes}))
 
     case impl().publish(id, args) do
       {:ok, %HTTPoison.Response{status_code: status_code, body: _body}}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Postoffice.MixProject do
   def project do
     [
       app: :postoffice,
-      version: "0.18.11",
+      version: "0.19.0",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/test/postoffice/http_worker_test.exs
+++ b/test/postoffice/http_worker_test.exs
@@ -31,7 +31,14 @@ defmodule Postoffice.HttpWorkerTest do
         "attributes" => %{"hive_id" => "vlc"}
       }
 
-      expect(HttpMock, :publish, fn _id, ^args ->
+      expected_args = %{
+        "consumer_id" => publisher.id,
+        "target" => publisher.target,
+        "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+        "attributes" => %{"hive_id" => "vlc"}
+      }
+
+      expect(HttpMock, :publish, fn _id, ^expected_args ->
         {:ok, %HTTPoison.Response{status_code: 201}}
       end)
 
@@ -49,7 +56,14 @@ defmodule Postoffice.HttpWorkerTest do
         "attributes" => %{"hive_id" => "vlc"}
       }
 
-      expect(HttpMock, :publish, fn _id, ^args ->
+      expected_args = %{
+        "consumer_id" => publisher.id,
+        "target" => publisher.target,
+        "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+        "attributes" => %{"hive_id" => "vlc"}
+      }
+
+      expect(HttpMock, :publish, fn _id, ^expected_args ->
         {:ok, %HTTPoison.Response{status_code: 201}}
       end)
 
@@ -68,7 +82,14 @@ defmodule Postoffice.HttpWorkerTest do
         "attributes" => %{"hive_id" => "vlc"}
       }
 
-      expect(HttpMock, :publish, fn _id, ^args ->
+      expected_args = %{
+        "consumer_id" => publisher.id,
+        "target" => publisher.target,
+        "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+        "attributes" => %{"hive_id" => "vlc"}
+      }
+
+      expect(HttpMock, :publish, fn _id, ^expected_args ->
         {:ok, %HTTPoison.Response{status_code: 302}}
       end)
 
@@ -86,7 +107,14 @@ defmodule Postoffice.HttpWorkerTest do
         "attributes" => %{"hive_id" => "vlc"}
       }
 
-      expect(HttpMock, :publish, fn _id, ^args ->
+      expected_args = %{
+        "consumer_id" => publisher.id,
+        "target" => publisher.target,
+        "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+        "attributes" => %{"hive_id" => "vlc"}
+      }
+
+      expect(HttpMock, :publish, fn _id, ^expected_args ->
         {:ok, %HTTPoison.Response{status_code: 302}}
       end)
 
@@ -105,7 +133,14 @@ defmodule Postoffice.HttpWorkerTest do
         "attributes" => %{"hive_id" => "vlc"}
       }
 
-      expect(HttpMock, :publish, fn _id, ^args ->
+      expected_args = %{
+        "consumer_id" => publisher.id,
+        "target" => publisher.target,
+        "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+        "attributes" => %{"hive_id" => "vlc"}
+      }
+
+      expect(HttpMock, :publish, fn _id, ^expected_args ->
         {:error, %HTTPoison.Error{reason: "Fake error"}}
       end)
 
@@ -123,7 +158,14 @@ defmodule Postoffice.HttpWorkerTest do
         "attributes" => %{"hive_id" => "vlc"}
       }
 
-      expect(HttpMock, :publish, fn _id, ^args ->
+      expected_args = %{
+        "consumer_id" => publisher.id,
+        "target" => publisher.target,
+        "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+        "attributes" => %{"hive_id" => "vlc"}
+      }
+
+      expect(HttpMock, :publish, fn _id, ^expected_args ->
         {:error, %HTTPoison.Error{reason: "Fake error"}}
       end)
 
@@ -143,7 +185,14 @@ defmodule Postoffice.HttpWorkerTest do
       "attributes" => %{"hive_id" => "vlc"}
     }
 
-    expect(HttpMock, :publish, fn _id, ^args ->
+    expected_args = %{
+      "consumer_id" => publisher.id,
+      "target" => publisher.target,
+      "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+      "attributes" => %{"hive_id" => "vlc"}
+    }
+
+    expect(HttpMock, :publish, fn _id, ^expected_args ->
       {:ok, %HTTPoison.Response{status_code: 201}}
     end)
 


### PR DESCRIPTION
In order to receive the attributes in HTTP endpoints we want to add them to the payload

Note: This is a proposal