### PR TITLE
Disable historical data by an environment variable

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_SHA:
 
     steps:
       - uses: actions/checkout@v3

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,3 +6,4 @@ Thank you!
 * Sergio Revilla (@elreplicante)
 * Lucas Yarza (@lucasyarza)
 * Adrià Sansaloni (@jsansaloni)
+* Awais (@awaistkd)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ export APP_COMMAND := mix phx.server
 endif
 
 ifeq ($(MIX_ENV),)
-export MIX_ENV := dev
+export MIX_ENV := test
 endif
 
 test: ## Run test suite in project's main container

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,6 @@ ifeq ($(APP_COMMAND),)
 export APP_COMMAND := mix phx.server
 endif
 
-ifeq ($(MIX_ENV),)
-export MIX_ENV := test
-endif
-
 test: ## Run test suite in project's main container
 	$(DOCKER_COMPOSE_COMMAND) exec -T $(POSTOFFICE_SERVICE) mix test
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ To start postoffice bundle with docker:
 * `CLEAN_MESSAGES_CRONTAB` defines when the Oban cronjob to clean historical data from the `sent_messages` table should be run.  Must be a valid crontab declaration.
 * `CLUSTER_NAME` defines cluster name to know the source of historical data in pubsub from different clusters
 * `PUBSUB_HISTORICAL_TOPIC_NAME` defines the name of pubsub topic to send historical data. Default `postoffice-sent-messages`
+* `ENABLE_HISTORICAL_DATA` defines if you want to send the historical data to Pub/Sub. Default `true`
 
 ## Clustering
 Postoffice has been developed to be used forming a cluster. We use [libcluster](https://github.com/bitwalker/libcluster) under the hood to create the cluster. You can take a look at its documentation in case you want to tune settings.

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -9,6 +9,7 @@ config :postoffice, clean_messages_threshold: {:system, "CLEAN_MESSAGES_THRESHOL
 config :postoffice, clean_messages_crontab: {:system, "CLEAN_MESSAGES_CRONTAB", default: "0 12 * * 0"}
 config :postoffice, cluster_name: {:system, "CLUSTER_NAME", default: "postoffice"}
 config :postoffice, pubsub_historical_topic_name: {:system, "PUBSUB_HISTORICAL_TOPIC_NAME", default: "postoffice-sent-messages"}
+config :postoffice, enable_historical_data: {:system, "ENABLE_HISTORICAL_DATA", default: true}
 
 config :postoffice, Postoffice.Repo,
   username: {:system, "DB_USERNAME", default: "postgres"},

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,8 +17,6 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.local
     image: $DOCKER_NAMESPACE/$DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG$DOCKER_BRANCH_NAME
-    environment:
-      - MIX_ENV
     env_file:
       - envfiles/local.env
     depends_on:
@@ -33,9 +31,6 @@ services:
 
   app:
     image: $DOCKER_NAMESPACE/$DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG$DOCKER_BRANCH_NAME
-    environment:
-      - MIX_ENV
-      - GITHUB_TOKEN
     env_file:
       - envfiles/local.env
     restart: on-failure

--- a/lib/postoffice/workers/http.ex
+++ b/lib/postoffice/workers/http.ex
@@ -118,4 +118,8 @@ defmodule Postoffice.Workers.Http do
   defp impl_pubsub do
     Application.get_env(:postoffice, :pubsub_consumer_impl, Postoffice.Adapters.Pubsub)
   end
+
+  defp is_enable_historical_data do
+    Application.get_env(:postoffice, :enable_historical_data, true)
+  end
 end

--- a/lib/postoffice/workers/http.ex
+++ b/lib/postoffice/workers/http.ex
@@ -45,7 +45,7 @@ defmodule Postoffice.Workers.Http do
           target: target
         )
 
-        if is_enable_historical_data do
+        if is_enable_historical_data() do
           historical_pubsub_args = %{
             "consumer_id" => consumer_id,
             "target" => Application.get_env(:postoffice, :pubsub_historical_topic_name),

--- a/lib/postoffice/workers/http.ex
+++ b/lib/postoffice/workers/http.ex
@@ -45,20 +45,22 @@ defmodule Postoffice.Workers.Http do
           target: target
         )
 
-        historical_pubsub_args = %{
-          "consumer_id" => consumer_id,
-          "target" => Application.get_env(:postoffice, :pubsub_historical_topic_name),
-          "payload" => %{
+        if is_enable_historical_data do
+          historical_pubsub_args = %{
             "consumer_id" => consumer_id,
-            "target" => target,
-            "type" => "http",
-            "message_payload" => Map.get(args, "payload"),
-            "attributes" => attributes,
-          },
-          "attributes" => %{"cluster_name" => Application.get_env(:postoffice, :cluster_name)}
-        }
+            "target" => Application.get_env(:postoffice, :pubsub_historical_topic_name),
+            "payload" => %{
+              "consumer_id" => consumer_id,
+              "target" => target,
+              "type" => "http",
+              "message_payload" => Map.get(args, "payload"),
+              "attributes" => attributes,
+            },
+            "attributes" => %{"cluster_name" => Application.get_env(:postoffice, :cluster_name)}
+          }
 
-        impl_pubsub().publish(id, historical_pubsub_args)
+          impl_pubsub().publish(id, historical_pubsub_args)
+        end
 
         {:ok, :sent}
 

--- a/lib/postoffice/workers/pubsub.ex
+++ b/lib/postoffice/workers/pubsub.ex
@@ -39,21 +39,22 @@ defmodule Postoffice.Workers.Pubsub do
         Logger.info("Successfully sent pubsub message",
           target: target
         )
-
-        historical_pubsub_args = %{
-          "consumer_id" => consumer_id,
-          "target" => Application.get_env(:postoffice, :pubsub_historical_topic_name),
-          "payload" => %{
+        if is_enable_historical_data() do
+          historical_pubsub_args = %{
             "consumer_id" => consumer_id,
-            "target" => target,
-            "type" => "pubsub",
-            "message_payload" => Map.get(args, "payload"),
-            "attributes" => attributes,
-          },
-          "attributes" => %{"cluster_name" => Application.get_env(:postoffice, :cluster_name)}
-        }
+            "target" => Application.get_env(:postoffice, :pubsub_historical_topic_name),
+            "payload" => %{
+              "consumer_id" => consumer_id,
+              "target" => target,
+              "type" => "pubsub",
+              "message_payload" => Map.get(args, "payload"),
+              "attributes" => attributes,
+            },
+            "attributes" => %{"cluster_name" => Application.get_env(:postoffice, :cluster_name)}
+          }
 
-        impl().publish(id, historical_pubsub_args)
+          impl().publish(id, historical_pubsub_args)
+        end
 
         {:ok, :sent}
 

--- a/lib/postoffice/workers/pubsub.ex
+++ b/lib/postoffice/workers/pubsub.ex
@@ -87,4 +87,8 @@ defmodule Postoffice.Workers.Pubsub do
   defp impl do
     Application.get_env(:postoffice, :pubsub_consumer_impl, Postoffice.Adapters.Pubsub)
   end
+
+  defp is_enable_historical_data do
+    Application.get_env(:postoffice, :enable_historical_data, true)
+  end
 end

--- a/test/postoffice/http_worker_test.exs
+++ b/test/postoffice/http_worker_test.exs
@@ -108,29 +108,10 @@ defmodule Postoffice.HttpWorkerTest do
         "attributes" => %{"hive_id" => "vlc"}
       }
 
-      expected_args = %{
-        "consumer_id" => publisher.id,
-        "target" => publisher.target,
-        "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
-        "attributes" => %{"hive_id" => "vlc"}
-      }
-
-      expect(HttpMock, :publish, fn _id, ^expected_args ->
+      expect(HttpMock, :publish, fn _id, _expected_args ->
         {:ok, %HTTPoison.Response{status_code: 201}}
       end)
 
-      # expected_pubsub_args = %{
-      #   "consumer_id" => publisher.id,
-      #   "target" => "postoffice-sent-messages",
-      #   "payload" => %{
-      #     "consumer_id" => publisher.id,
-      #     "target" => publisher.target,
-      #     "type" => publisher.type,
-      #     "message_payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
-      #     "attributes" => %{"hive_id" => "vlc"},
-      #   },
-      #   "attributes" => %{"cluster_name" => "vlc"}
-      # }
 
       expect(PubsubMock, :publish, 0, fn  _id, _expected_pubsub_args ->
         {:ok, %PublishResponse{}}
@@ -138,6 +119,8 @@ defmodule Postoffice.HttpWorkerTest do
 
       perform_job(HttpWorker, args)
       assert Kernel.length(HistoricalData.list_sent_messages()) == 0
+
+      Application.delete_env(:postoffice, :enable_historical_data)
 
     end
 

--- a/test/postoffice/http_worker_test.exs
+++ b/test/postoffice/http_worker_test.exs
@@ -95,6 +95,52 @@ defmodule Postoffice.HttpWorkerTest do
 
     end
 
+    test "historical data is not created when enabled_historical_data is false" do
+      topic = Fixtures.create_topic()
+      publisher = Fixtures.create_publisher(topic)
+
+      Application.put_env(:postoffice, :enable_historical_data, false)
+
+      args = %{
+        "consumer_id" => publisher.id,
+        "target" => publisher.target,
+        "payload" => %{"action" => "test"},
+        "attributes" => %{"hive_id" => "vlc"}
+      }
+
+      expected_args = %{
+        "consumer_id" => publisher.id,
+        "target" => publisher.target,
+        "payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+        "attributes" => %{"hive_id" => "vlc"}
+      }
+
+      expect(HttpMock, :publish, fn _id, ^expected_args ->
+        {:ok, %HTTPoison.Response{status_code: 201}}
+      end)
+
+      # expected_pubsub_args = %{
+      #   "consumer_id" => publisher.id,
+      #   "target" => "postoffice-sent-messages",
+      #   "payload" => %{
+      #     "consumer_id" => publisher.id,
+      #     "target" => publisher.target,
+      #     "type" => publisher.type,
+      #     "message_payload" => %{"action" => "test", "attributes" => %{"hive_id" => "vlc"}},
+      #     "attributes" => %{"hive_id" => "vlc"},
+      #   },
+      #   "attributes" => %{"cluster_name" => "vlc"}
+      # }
+
+      expect(PubsubMock, :publish, 0, fn  _id, _expected_pubsub_args ->
+        {:ok, %PublishResponse{}}
+      end)
+
+      perform_job(HttpWorker, args)
+      assert Kernel.length(HistoricalData.list_sent_messages()) == 0
+
+    end
+
     test "message is not send if response code is out of 2xx range" do
       topic = Fixtures.create_topic()
       publisher = Fixtures.create_publisher(topic)


### PR DESCRIPTION
We added the possibility to disable sending historical data to PubSub using an environment variable "ENABLE_HISTORICAL_DATA"