### PR TITLE
Fix local reload assets

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -26,7 +26,8 @@ config :postoffice, PostofficeWeb.Endpoint,
       "node_modules/webpack/bin/webpack.js",
       "--mode",
       "development",
-      "--watch-stdin",
+      "--watch",
+      "--watch-options-stdin",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]


### PR DESCRIPTION
Fix this error
```
app           |[error] Task #PID<0.11490.0> started from PostofficeWeb.Endpoint terminating
app           | ** (stop) :watcher_command_error
app           |     (phoenix 1.6.15) lib/phoenix/endpoint/watcher.ex:55: Phoenix.Endpoint.Watcher.watch/2
app           |     (elixir 1.14.2) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
app           |     (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
app           | Function: &Phoenix.Endpoint.Watcher.watch/2
app           |     Args: ["node", ["node_modules/webpack/bin/webpack.js", "--mode", "development", "--watch-stdin", {:cd, "/app/assets"}]]
app           | [webpack-cli] Error: Unknown option '--watch-stdin'
app           | [webpack-cli] Run 'webpack --help' to see available commands and options
```